### PR TITLE
If we all put our mysql connector in our c drive it will make things easier

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="D:/Sophy_DMACC/jarFolder/mysql-connector-java-5.1.37-bin.jar"/>
+	<classpathentry kind="lib" path="C:/mysql-connector-java-5.1.37-bin.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
We should all put our mysql connector in the same folder. Putting it in the c drive is probably the easiest. This will make switching between branches easier. 

Also, we should consider choosing a default password like "ladybug" for all of our mysql databases? I have to change that each time I change branches as well. 

@aharbert678 @sophyyang @mlarsen3
